### PR TITLE
`PHP_XDEBUG_HOST` 기본값 변경

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,7 @@ XDEBUG_REMOTE_HOST=$PHP_INI_PATH/xdebug_remote_host.ini
 # Enable XDebug if needed
 PHP_INI_DIR=/usr/local/etc/php/conf.d
 PHP_XDEBUG_INI=${PHP_INI_DIR}/99-xdebug.ini
-PHP_XDEBUG_HOST=${XDEBUG_HOST:-$(/sbin/ip route|awk '/default/ { print $3 }')}
+PHP_XDEBUG_HOST=${XDEBUG_HOST:-host.docker.internal}
 PHP_EXTENSION_DIR=$(php-config --extension-dir)
 if [ "${XDEBUG_ENABLE}" == "1" ]
 then


### PR DESCRIPTION
컨테이너 내에서 `ip route` 명령어로 확인되는 IP는 환경에 따라 접속이 되지 않을 수 있습니다. Docker 18.03 이후 호스트로의 접근은 [`host.docker.internal`](https://docs.docker.com/docker-for-windows/networking/)을 사용할 것을 권장하고 있으므로 이에 맞춰 기본값을 변경합니다.