### PR TITLE
Debian 미러 서버 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 RUN rm -rfv /var/lib/apt/lists/* \
-&& sed -i "s/http:\/\/deb.debian.org/http:\/\/ftp.harukasan.org/" /etc/apt/sources.list \
-&& sed -i "s/http:\/\/security.debian.org/http:\/\/ftp.harukasan.org/" /etc/apt/sources.list
+&& sed -i "s/http:\/\/deb.debian.org/http:\/\/cloudfront.debian.net/" /etc/apt/sources.list \
+&& sed -i "s/http:\/\/security.debian.org/http:\/\/cloudfront.debian.net/" /etc/apt/sources.list
 
 # Install common
 RUN docker-php-source extract \

--- a/projects/admin/Dockerfile
+++ b/projects/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM ridibooks/platform-apache-base:1.0.1-php73-stretch
+FROM ridibooks/platform-apache-base:1.0.2-php73-stretch
 
 # Require for openjdk-8-jre
 RUN mkdir -p /usr/share/man/man1

--- a/projects/api/Dockerfile
+++ b/projects/api/Dockerfile
@@ -1,3 +1,3 @@
-FROM ridibooks/platform-apache-base:1.0.1-php73-stretch
+FROM ridibooks/platform-apache-base:1.0.2-php73-stretch
 
 RUN apt-get autoclean -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/projects/book-api/Dockerfile
+++ b/projects/book-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ridibooks/platform-apache-base:1.0.1-php73-stretch
+FROM ridibooks/platform-apache-base:1.0.2-php73-stretch
 
 RUN apt-get update \
 && apt-get install -y --no-install-recommends \

--- a/projects/cp/Dockerfile
+++ b/projects/cp/Dockerfile
@@ -1,4 +1,4 @@
-FROM ridibooks/platform-apache-base:1.0.1-php73-stretch
+FROM ridibooks/platform-apache-base:1.0.2-php73-stretch
 
 # Require for openjdk-8-jre
 RUN mkdir -p /usr/share/man/man1

--- a/projects/download/Dockerfile
+++ b/projects/download/Dockerfile
@@ -1,4 +1,4 @@
-FROM ridibooks/platform-apache-base:1.0.1-php73-stretch
+FROM ridibooks/platform-apache-base:1.0.2-php73-stretch
 
 # Require for openjdk-8-jre
 RUN mkdir -p /usr/share/man/man1

--- a/projects/finance/Dockerfile
+++ b/projects/finance/Dockerfile
@@ -1,4 +1,4 @@
-FROM ridibooks/platform-apache-base:1.0.1-php73-stretch
+FROM ridibooks/platform-apache-base:1.0.2-php73-stretch
 
 # Install required programs
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/projects/misc/Dockerfile
+++ b/projects/misc/Dockerfile
@@ -1,4 +1,4 @@
-FROM ridibooks/platform-apache-base:1.0.1-php73-stretch
+FROM ridibooks/platform-apache-base:1.0.2-php73-stretch
 
 # Install required programs
 RUN apt-get update && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
패키지 미러 서버를 `ftp.harukasan.org`에서 `cloudfront.debian.net`으로 변경합니다.

**배포 스크립트**
```bash
bin/build_root.sh 1.0.2-php73-stretch 7.3.17
bin/push.sh ridibooks/platform-apache-base 1.0.2-php73-stretch

bin/build_project.sh admin 2.1.2
bin/push.sh ridibooks/platform-apache-base 2.1.2-admin

bin/build_project.sh api 2.0.2
bin/push.sh ridibooks/platform-apache-base 2.0.2-api

bin/build_project.sh book-api 2.0.2
bin/push.sh ridibooks/platform-apache-base 2.0.2-book-api

bin/build_project.sh cp 2.1.2
bin/push.sh ridibooks/platform-apache-base 2.1.2-cp

bin/build_project.sh download 2.1.2
bin/push.sh ridibooks/platform-apache-base 2.1.2-download

bin/build_project.sh finance 2.0.2
bin/push.sh ridibooks/platform-apache-base 2.0.2-finance

bin/build_project.sh misc 2.0.2
bin/push.sh ridibooks/platform-apache-base 2.0.2-misc
```